### PR TITLE
Fix issues with using date library under ruby 1.9.3

### DIFF
--- a/lib/core_ext.rb
+++ b/lib/core_ext.rb
@@ -1,20 +1,3 @@
-## 
-# Extend Time class to offset the time that 'now' returns.  This
-# provides the opening to "warp time" for any tests checking for
-# time-based limitations.  Perhaps one needs to check hourly
-# limits, common time borders like midnight, etc.
-if !Time.respond_to?(:real_now)  # assures there is no infinite looping when aliasing #now
-  Time.class_eval do
-    class << self
-      attr_accessor :testing_offset
-      
-      alias_method :real_now, :now
-      def now
-        real_now - testing_offset
-      end
-      alias_method :new, :now
-      
-    end
-  end
-end
-Time.testing_offset = 0
+require File.join File.dirname(__FILE__), 'core_ext/time'
+require File.join File.dirname(__FILE__), 'core_ext/date'
+require File.join File.dirname(__FILE__), 'core_ext/date_time'

--- a/lib/core_ext/date.rb
+++ b/lib/core_ext/date.rb
@@ -1,0 +1,13 @@
+require 'date'
+
+# Extend Date class to generate 'today' from modified Time.now
+Date.class_eval do
+  class << self
+
+    def today
+      Time.now.to_date
+    end
+
+  end
+end
+  

--- a/lib/core_ext/date_time.rb
+++ b/lib/core_ext/date_time.rb
@@ -1,0 +1,12 @@
+require 'date'
+
+# Extend DateTime class to generate 'now' from modified Time.now
+DateTime.class_eval do
+  class << self
+
+    def now
+      Time.now.to_datetime
+    end
+
+  end
+end

--- a/lib/core_ext/time.rb
+++ b/lib/core_ext/time.rb
@@ -1,0 +1,20 @@
+## 
+# Extend Time class to offset the time that 'now' returns.  This
+# provides the opening to "warp time" for any tests checking for
+# time-based limitations.  Perhaps one needs to check hourly
+# limits, common time borders like midnight, etc.
+if !Time.respond_to?(:real_now)  # assures there is no infinite looping when aliasing #now
+  Time.class_eval do
+    class << self
+      attr_accessor :testing_offset
+      
+      alias_method :real_now, :now
+      def now
+        real_now - testing_offset
+      end
+      alias_method :new, :now
+      
+    end
+  end
+end
+Time.testing_offset = 0

--- a/test/time_warp_test.rb
+++ b/test/time_warp_test.rb
@@ -93,4 +93,27 @@ class TimeWarpTest < Test::Unit::TestCase
       assert_equal    0, Time.now.utc.min
     end
   end
+  
+  def test_pretend_now_with_date
+    # Date.today returns the current date in local time, not UTC
+    # use local time to test this instead
+    
+    pretend_now_is(Time.local(2008,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 2008 (local)
+      assert_equal 2008, Date.today.year
+      assert_equal    7, Date.today.month
+      assert_equal   25, Date.today.day
+    end
+  end
+  
+  def test_pretend_now_with_date_time
+    pretend_now_is(Time.utc(2008,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 UTC 2008
+      date_time = DateTime.now.new_offset(0) # UTC DateTime
+      
+      assert_equal 2008, date_time.year
+      assert_equal    7, date_time.month
+      assert_equal   25, date_time.day
+      assert_equal    6, date_time.hour
+      assert_equal   15, date_time.min
+    end
+  end
 end

--- a/time-warp.gemspec
+++ b/time-warp.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new do |s|
   s.description = "TimeWarp is a ruby library for manipulating times in automated tests."
   s.has_rdoc = true
   s.authors   = ["Barry Hess"]
-  s.files    = ["MIT-LICENSE", "Rakefile", "README.md", "lib/core_ext.rb", "lib/time_warp.rb", "lib/time-warp.rb", "tasks/time_warp_tasks.rake"]
+  s.files    = ["MIT-LICENSE", "Rakefile", "README.md", "lib/core_ext/time.rb", "lib/core_ext/date.rb", "lib/core_ext/date_time.rb", "lib/core_ext.rb", "lib/time_warp.rb", "lib/time-warp.rb", "tasks/time_warp_tasks.rake"]
   s.test_files = ["test/test_helper.rb", "test/time_warp_test.rb"]
 end


### PR DESCRIPTION
Under Ruby 1.9.3, `Date.today` and `DateTime.now` are generated directly from system time instead of using `Time.now`. This caused the methods to return the actual current date/time instead of the time-warp modified ones. I extended the classes to base these methods off of `Time.now`, like they do in 1.9.2.

Instead of cramming all of these extensions in `core_ext.rb`, I placed them all in separate files in a `core_ext` directory.

I had also considered extending these classes to maintain offsets parallel to the `Time` class, but because `Date` doesn't have any time information, creating offsets with a precision of less than one day would be impossible. Always generating from `Time.now` is less than ideal, but I think it's okay if time-warp is only loaded when running tests.
