### PR TITLE
Rspec compatibility is added

### DIFF
--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -34,3 +34,30 @@ module Test # :nodoc:
     end
   end
 end
+
+module RSpec
+  module Core
+    class ExampleGroup
+     # Time warp to the specified time for the duration of the passed block.
+      def reset_to_real_time
+        Time.testing_offset = 0
+      end
+      def pretend_now_is(*args)
+        Time.testing_offset = Time.now - time_from(*args)
+        if block_given?
+          begin
+            yield
+          ensure
+            reset_to_real_time
+          end
+        end
+      end
+    private
+      def time_from(*args)
+        return args[0] if 1 == args.size && args[0].is_a?(Time)
+        return args[0].to_time if 1 == args.size && args[0].respond_to?(:to_time)  # For example, if it's a Date.
+        Time.utc(*args)
+      end
+    end
+  end
+end

--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -1,22 +1,5 @@
 require File.join File.dirname(__FILE__), 'core_ext'
 
-module Test # :nodoc:
-  module Unit # :nodoc:
-    class TestCase
-      include TimeWarpAbility
-    end
-  end
-end
-
-module RSpec
-  module Core
-    class ExampleGroup
-      include TimeWarpAbility
-     # Time warp to the specified time for the duration of the passed block.
-    end
-  end
-end
-
 module TimeWarpAbility
 
     def reset_to_real_time
@@ -41,4 +24,21 @@ module TimeWarpAbility
       return args[0].to_time if 1 == args.size && args[0].respond_to?(:to_time)  # For example, if it's a Date.
       Time.utc(*args)
     end
+end
+
+module Test # :nodoc:
+  module Unit # :nodoc:
+    class TestCase
+      include ::TimeWarpAbility
+    end
+  end
+end
+
+module RSpec
+  module Core
+    class ExampleGroup
+      include ::TimeWarpAbility
+     # Time warp to the specified time for the duration of the passed block.
+    end
+  end
 end

--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -3,34 +3,7 @@ require File.join File.dirname(__FILE__), 'core_ext'
 module Test # :nodoc:
   module Unit # :nodoc:
     class TestCase
-
-      ##
-      # Time warp to the specified time for the duration of the passed block.
-      def pretend_now_is(*args)
-        Time.testing_offset = Time.now - time_from(*args)
-        if block_given?
-          begin
-            yield
-          ensure
-            reset_to_real_time
-          end
-        end
-      end
-      
-      ##
-      # Reset to real time.
-      def reset_to_real_time
-        Time.testing_offset = 0
-      end
-    
-    private
-    
-      def time_from(*args)
-        return args[0] if 1 == args.size && args[0].is_a?(Time)
-        return args[0].to_time if 1 == args.size && args[0].respond_to?(:to_time)  # For example, if it's a Date.
-        Time.utc(*args)
-      end
-
+      include TimeWarpAbility
     end
   end
 end
@@ -38,26 +11,34 @@ end
 module RSpec
   module Core
     class ExampleGroup
+      include TimeWarpAbility
      # Time warp to the specified time for the duration of the passed block.
-      def reset_to_real_time
-        Time.testing_offset = 0
-      end
-      def pretend_now_is(*args)
-        Time.testing_offset = Time.now - time_from(*args)
-        if block_given?
-          begin
-            yield
-          ensure
-            reset_to_real_time
-          end
-        end
-      end
-    private
-      def time_from(*args)
-        return args[0] if 1 == args.size && args[0].is_a?(Time)
-        return args[0].to_time if 1 == args.size && args[0].respond_to?(:to_time)  # For example, if it's a Date.
-        Time.utc(*args)
-      end
     end
   end
+end
+
+module TimeWarpAbility
+
+    def reset_to_real_time
+      Time.testing_offset = 0
+    end
+
+    def pretend_now_is(*args)
+      Time.testing_offset = Time.now - time_from(*args)
+      if block_given?
+        begin
+          yield
+        ensure
+          reset_to_real_time
+        end
+      end
+    end
+
+  private
+
+    def time_from(*args)
+      return args[0] if 1 == args.size && args[0].is_a?(Time)
+      return args[0].to_time if 1 == args.size && args[0].respond_to?(:to_time)  # For example, if it's a Date.
+      Time.utc(*args)
+    end
 end


### PR DESCRIPTION
Hi,

I extracted the "pretend_..." and the other two methods into a module and included into the right rspec class.
This way it can be used very conveniently in rspec too :)

I like this syntax :)
pretend_... {
 #test code syntax
}

Now this works with rspec too :)
