### PR TITLE
Error when other classes that extend Time call `now`

### DIFF
--- a/lib/core_ext/time.rb
+++ b/lib/core_ext/time.rb
@@ -10,7 +10,7 @@ if !Time.respond_to?(:real_now)  # assures there is no infinite looping when ali
       
       alias_method :real_now, :now
       def now
-        real_now - testing_offset
+        real_now - Time.testing_offset
       end
       alias_method :new, :now
       

--- a/test/time_warp_test.rb
+++ b/test/time_warp_test.rb
@@ -114,4 +114,16 @@ class TimeWarpTest < Test::Unit::TestCase
       assert_equal   15, date_time.min
     end
   end
+
+  def test_pretend_now_with_inherited_time_class
+    eval "class MyTime < Time; end"
+    pretend_now_is(Time.utc(2008,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 UTC 2008
+      my_time = MyTime.now.utc
+      assert_equal 2008, my_time.year
+      assert_equal    7, my_time.month
+      assert_equal   25, my_time.day
+      assert_equal    6, my_time.hour
+      assert_equal   15, my_time.min
+    end
+  end
 end


### PR DESCRIPTION
Ran into a problem where an OpenOffice parsing gem was failing with "no implicit conversion to float from nil". Tracked it down to a DOSTime class that extends Time that was failing due to interactions with time-warp.
Included is a small tweak to stop that happening, with a test.
