### PR TITLE
Stop accidentally defining RSpec

### DIFF
--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -26,12 +26,10 @@ module TimeWarpAbility
   end
 end
 
-if defined?(Test)
-  module Test # :nodoc:
-    module Unit # :nodoc:
-      class TestCase
-        include ::TimeWarpAbility
-      end
+module Test # :nodoc:
+  module Unit # :nodoc:
+    class TestCase
+      include ::TimeWarpAbility
     end
   end
 end

--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -42,11 +42,13 @@ module MiniTest
   end
 end
 
-module RSpec
-  module Core
-    class ExampleGroup
-      include ::TimeWarpAbility
-     # Time warp to the specified time for the duration of the passed block.
+if defined?(RSpec)
+  module RSpec
+    module Core
+      class ExampleGroup
+        include ::TimeWarpAbility
+       # Time warp to the specified time for the duration of the passed block.
+      end
     end
   end
 end

--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -2,42 +2,46 @@ require File.join File.dirname(__FILE__), 'core_ext'
 
 module TimeWarpAbility
 
-    def reset_to_real_time
-      Time.testing_offset = 0
-    end
+  def reset_to_real_time
+    Time.testing_offset = 0
+  end
 
-    def pretend_now_is(*args)
-      Time.testing_offset = Time.now - time_from(*args)
-      if block_given?
-        begin
-          yield
-        ensure
-          reset_to_real_time
-        end
+  def pretend_now_is(*args)
+    Time.testing_offset = Time.now - time_from(*args)
+    if block_given?
+      begin
+        yield
+      ensure
+        reset_to_real_time
       end
     end
+  end
 
   private
 
-    def time_from(*args)
-      return args[0] if 1 == args.size && args[0].is_a?(Time)
-      return args[0].to_time if 1 == args.size && args[0].respond_to?(:to_time)  # For example, if it's a Date.
-      Time.utc(*args)
-    end
+  def time_from(*args)
+    return args[0] if 1 == args.size && args[0].is_a?(Time)
+    return args[0].to_time if 1 == args.size && args[0].respond_to?(:to_time)  # For example, if it's a Date.
+    Time.utc(*args)
+  end
 end
 
-module Test # :nodoc:
-  module Unit # :nodoc:
-    class TestCase
-      include ::TimeWarpAbility
+if defined?(Test)
+  module Test # :nodoc:
+    module Unit # :nodoc:
+      class TestCase
+        include ::TimeWarpAbility
+      end
     end
   end
 end
 
-module MiniTest
-  class Unit
-    class TestCase
-      include ::TimeWarpAbility
+if defined?(MiniTest)
+  module MiniTest
+    class Unit
+      class TestCase
+        include ::TimeWarpAbility
+      end
     end
   end
 end
@@ -47,7 +51,7 @@ if defined?(RSpec)
     module Core
       class ExampleGroup
         include ::TimeWarpAbility
-       # Time warp to the specified time for the duration of the passed block.
+        # Time warp to the specified time for the duration of the passed block.
       end
     end
   end


### PR DESCRIPTION
In `lib/time_warp.rb`, `TimeWarpAbility` is monkey-patched onto `RSpec::Core::ExampleGroup`. `RSpec` is the root module of RSpec 2 (in RSpec 1, it is `Spec`). Some other gems rely on this fact to determine whether they are being loaded in the context of RSpec 1 or 2, so defining RSpec here can cause them to believe falsely that they are in the context of RSpec 2, and b0rk.
