### PR TITLE
Fixed Time.new with arguments in Ruby 1.9.2+ 

### DIFF
--- a/lib/core_ext/time.rb
+++ b/lib/core_ext/time.rb
@@ -9,10 +9,17 @@ if !Time.respond_to?(:real_now)  # assures there is no infinite looping when ali
       attr_accessor :testing_offset
       
       alias_method :real_now, :now
+      alias_method :real_new, :new
       def now
         real_now.class.at(real_now - Time.testing_offset)
       end
-      alias_method :new, :now
+      def new(*args)
+        if args.any?
+          real_new(*args)
+        else
+          now
+        end
+      end
       
     end
   end

--- a/test/time_warp_test.rb
+++ b/test/time_warp_test.rb
@@ -114,6 +114,22 @@ class TimeWarpTest < Test::Unit::TestCase
       assert_equal   15, date_time.min
     end
   end
+  
+  
+  major, minor, tiny = RUBY_VERSION.split('.').map{|s| s.to_i}
+  if major.to_i==1 && minor.to_i == 9 && tiny >= 2        
+    def test_19_time_constructor_with_arguments
+      assert_nothing_raised do
+        t = ::Time.new(2005, 11, 10, 12, 0, 2, 0)
+        assert_equal 2005, t.year
+        assert_equal 11, t.month
+        assert_equal 10, t.day
+        assert_equal 12, t.hour
+        assert_equal 0, t.min
+        assert_equal 0, t.utc_offset
+      end
+  end    
+end
 
   def test_pretend_now_with_inherited_time_class
     eval <<-EVAL


### PR DESCRIPTION
The Ruby 1.9.2+ Time constructor can take arguments, which causes an ArgumentError once the aliasing happens:

```
1.9.3p194 :003 >   ::Time.new(2005, 11, 10, 12, 0, 2, 0)
 => 2005-11-10 12:00:02 +0000 
1.9.3p194 :004 > require 'time_warp'
 => true 
1.9.3p194 :005 > ::Time.new(2005, 11, 10, 12, 0, 2, 0)
ArgumentError: wrong number of arguments (7 for 0)
    from /Users/bortega/.rvm/gems/ruby-1.9.3-p194-i386/gems/time-warp-1.0.13/lib/core_ext/time.rb:12:in `now'
    from (irb):5
    from /Users/bortega/.rvm/rubies/ruby-1.9.3-p194-i386/bin/irb:16:in `<main>'

```
