### PR TITLE
Time.new now works correctly when passed arguments

### DIFF
--- a/lib/core_ext/time.rb
+++ b/lib/core_ext/time.rb
@@ -12,8 +12,11 @@ if !Time.respond_to?(:real_now)  # assures there is no infinite looping when ali
       def now
         real_now.class.at(real_now - Time.testing_offset)
       end
-      alias_method :new, :now
-      
+
+      alias_method :real_new, :new
+      def self.new(*args)
+        args.empty? ? now : real_new(*args)
+      end
     end
   end
 end


### PR DESCRIPTION
Under Ruby 1.9, you can initialize a Time object to a given time (rather than the system time) like this:

```
Time.new(2010,1,1,10) # Jan 1, 2010, 10:00am
```

`time-warp` breaks this behavior, which breaks some code which I'm trying to test. This patch fixes it.
