### PR TITLE
Modernized time-warp a bit with bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'minitest', '~> 5.0'
+gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,25 @@
+PATH
+  remote: .
+  specs:
+    time-warp (1.0.13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (3.1.2)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+    columnize (0.8.9)
+    debugger-linecache (1.2.0)
+    minitest (5.4.0)
+    rake (10.3.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.6)
+  byebug
+  minitest (~> 5.0)
+  rake
+  time-warp!

--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,13 @@
 require 'rake'
+require 'bundler/gem_tasks'
 require 'rake/testtask'
-require 'rake/rdoctask'
 
 desc 'Default: run unit tests.'
-task :default => :test
+task default: :test
 
 desc 'Test the time_warp plugin.'
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
+  t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = true
-end
-
-desc 'Generate documentation for the time_warp plugin.'
-Rake::RDocTask.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'TimeWarp'
-  rdoc.options << '--line-numbers' << '--inline-source'
-  rdoc.rdoc_files.include('README')
-  rdoc.rdoc_files.include('lib/**/*.rb')
 end

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,0 @@
-require './lib/time_warp'

--- a/lib/core_ext/time.rb
+++ b/lib/core_ext/time.rb
@@ -12,8 +12,11 @@ if !Time.respond_to?(:real_now)  # assures there is no infinite looping when ali
       def now
         real_now.class.at(real_now - Time.testing_offset)
       end
-      alias_method :new, :now
-      
+
+      alias_method :real_new, :new
+      def self.new(*args)
+        args.empty? ? now : real_new(*args)
+      end
     end
   end
 end

--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -50,3 +50,9 @@ module RSpec
     end
   end
 end
+
+module Minitest
+  class Test
+    include ::TimeWarpAbility
+  end
+end

--- a/tasks/time_warp_tasks.rake
+++ b/tasks/time_warp_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :time_warp do
-#   # Task goes here
-# end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,2 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../init.rb'
+require 'minitest/autorun'
+require 'time-warp'

--- a/test/time_warp_test.rb
+++ b/test/time_warp_test.rb
@@ -1,10 +1,10 @@
-require "./test/test_helper"
+require "test_helper"
 
-class TimeWarpTest < Test::Unit::TestCase
+class TimeWarpTest < Minitest::Test
   def test_test_unit_test_case_should_respond_to_pretend_now_is
     assert_equal true, self.respond_to?(:pretend_now_is)
   end
-  
+
   def test_pretend_now_is_should_set_now_back_in_time
     pretend_now_is(Time.utc(2008,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 UTC 2008
       assert_equal 2008, Time.now.utc.year
@@ -14,7 +14,7 @@ class TimeWarpTest < Test::Unit::TestCase
       assert_equal   15, Time.now.utc.min
     end
   end
-  
+
   def test_pretend_now_is_should_set_now_forward_in_time
     future_year = Time.now.year + 1
     pretend_now_is(Time.utc(future_year,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 UTC future_year
@@ -25,7 +25,7 @@ class TimeWarpTest < Test::Unit::TestCase
       assert_equal          15, Time.now.utc.min
     end
   end
-  
+
   def test_pretend_now_should_revert_to_real_now_after_block
     now        = Time.now
     now_year   = now.year
@@ -33,18 +33,18 @@ class TimeWarpTest < Test::Unit::TestCase
     now_day    = now.day
     now_hour   = now.hour
     now_minute = now.min
-    
+
     pretend_now_is(Time.utc(2008,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 UTC 2008
       # block of code
     end
-    
+
     assert_equal   now_year, Time.now.year
     assert_equal  now_month, Time.now.month
     assert_equal    now_day, Time.now.day
     assert_equal   now_hour, Time.now.hour
     assert_equal now_minute, Time.now.min
   end
-  
+
   def test_pretend_now_resolves_to_the_same_value_regardless_of_setting_by_time_argument_or_time_utc_arguments
     now_with_time_argument = now_with_time_utc_arguments = nil
     pretend_now_is(Time.utc(2008,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 UTC 2008
@@ -55,7 +55,7 @@ class TimeWarpTest < Test::Unit::TestCase
     end
     assert_equal now_with_time_argument.to_s, now_with_time_utc_arguments.to_s
   end
-  
+
   def test_pretend_now_without_a_block
     now        = Time.now
     now_year   = now.year
@@ -63,7 +63,7 @@ class TimeWarpTest < Test::Unit::TestCase
     now_day    = now.day
     now_hour   = now.hour
     now_minute = now.min
-    
+
     pretend_now_is(Time.utc(2008,"jul",25,6,15))
     assert_equal 2008, Time.now.utc.year
     assert_equal    7, Time.now.utc.month
@@ -71,14 +71,14 @@ class TimeWarpTest < Test::Unit::TestCase
     assert_equal    6, Time.now.utc.hour
     assert_equal   15, Time.now.utc.min
     reset_to_real_time
-    
+
     assert_equal   now_year, Time.now.year
     assert_equal  now_month, Time.now.month
     assert_equal    now_day, Time.now.day
     assert_equal   now_hour, Time.now.hour
     assert_equal now_minute, Time.now.min
   end
-  
+
   def test_pretend_now_with_an_object_that_responds_to_to_time
     # Date objects in rails have to_time methods, but without Rails, they don't so we fake it
     date = Object.new
@@ -93,7 +93,7 @@ class TimeWarpTest < Test::Unit::TestCase
       assert_equal    0, Time.now.utc.min
     end
   end
-  
+
   def test_pretend_now_with_date
     # Date.today returns the current date in local time, not UTC
     # use local time to test this instead
@@ -103,7 +103,7 @@ class TimeWarpTest < Test::Unit::TestCase
       assert_equal   25, Date.today.day
     end
   end
-  	  	
+
   def test_pretend_now_with_date_time
     pretend_now_is(Time.utc(2008,"jul",25,6,15)) do #=> Fri Jul 25 06:15:00 UTC 2008
       date_time = DateTime.now.new_offset(0) # UTC DateTime

--- a/test/time_warp_test.rb
+++ b/test/time_warp_test.rb
@@ -135,4 +135,14 @@ class TimeWarpTest < Minitest::Test
     end
   end
 
+  def test_time_constructor_with_arguments
+    time = ::Time.new(2005, 11, 10, 12, 0, 2, 0)
+
+    assert_equal 2005, time.year
+    assert_equal 11,   time.month
+    assert_equal 10,   time.day
+    assert_equal 12,   time.hour
+    assert_equal 0,    time.min
+    assert_equal 0,    time.utc_offset
+  end
 end

--- a/time-warp.gemspec
+++ b/time-warp.gemspec
@@ -1,13 +1,21 @@
-Gem::Specification.new do |s|
-  s.name     = "time-warp"
-  s.version  = "1.0.13"
-  s.date     = "2012-06-26"
-  s.summary  = "Warp time in your tests"
-  s.email    = "barry@getHarvest.com"
-  s.homepage = "http://github.com/harvesthq/time-warp"
-  s.description = "TimeWarp is a ruby library for manipulating times in automated tests."
-  s.has_rdoc = true
-  s.authors   = ["Barry Hess"]
-  s.files    = ["MIT-LICENSE", "Rakefile", "README.md", "lib/core_ext/time.rb", "lib/core_ext/date.rb", "lib/core_ext/date_time.rb", "lib/core_ext.rb", "lib/time_warp.rb", "lib/time-warp.rb", "tasks/time_warp_tasks.rake"]
-  s.test_files = ["test/test_helper.rb", "test/time_warp_test.rb"]
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "time-warp"
+  spec.version       = "1.0.13"
+  spec.authors       = ["Barry Hess"]
+  spec.email         = "barry@getHarvest.com"
+  spec.summary       = "Warp time in your tests"
+  spec.description   = "TimeWarp is a ruby library for manipulating times in automated tests."
+  spec.homepage      = "http://github.com/harvesthq/time-warp"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
/cc @bjhess @lorenzoplanas @tjschuck 
- Added bundler so we can build and release new gem versions with it. 
- Also using Minitest 5... because.
- Included a mix of #9 and #7 so that it works with ruby 1.9's `Time.new`.

Once merged we can release a new version.

Cheers!
