### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+
+script: bundle exec rake
+
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  - 2.1.1
+  - ruby-head
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head
+  - rbx-2
+  - ree

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ rvm:
   - jruby-head
   - rbx-2
   - ree
+
+matrix:
+  allow_failures:
+    - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'minitest', '~> 5.0'
-gem 'byebug'
+
+platforms :mri_20 do
+  gem 'byebug'
+end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## time-warp
 
+[![Build Status](https://travis-ci.org/harvesthq/time-warp.svg?branch=master)](https://travis-ci.org/harvesthq/time-warp)
+
 When writing tests, it is often desirable to bend time in order to test limits and edges of the day.  It is especially useful to warp time to test results across the timezones of the world.  Manipulating time is also useful to assure a day of the week, month or year every time the test runs.
 
 Some may say "Why not just mock `Time#now`?"  I see the point, but I find mocking around with baseline Ruby classes to be asking for trouble.  Eventually unusual behavior will rear its head and a day will be lost debugging tests - the most excruciating debugging one can be subjected to.

--- a/test/time_warp_test.rb
+++ b/test/time_warp_test.rb
@@ -136,6 +136,9 @@ class TimeWarpTest < Minitest::Test
   end
 
   def test_time_constructor_with_arguments
+    # Time.new does not take any arguments in 1.8
+    skip if RUBY_VERSION =~ /^1\.8/
+
     time = ::Time.new(2005, 11, 10, 12, 0, 2, 0)
 
     assert_equal 2005, time.year


### PR DESCRIPTION
@mrsimo @bjhess Seems like the easiest way to guarantee that https://github.com/harvesthq/time-warp/pull/11 doesn't slip in the future is to automatically check for it.

This adds Travis with a matrix that covers a pretty wide spread of Rubies (same ones I use for bcrypt-ruby).

jruby-head kept failing with a thing that I didn't really feel like debugging, so right now the matrix is allowing failures for that.  ¯\_(ツ)_/¯
