### PR TITLE
Stop accidentally defining RSpec

### DIFF
--- a/lib/time_warp.rb
+++ b/lib/time_warp.rb
@@ -34,25 +34,31 @@ module Test # :nodoc:
   end
 end
 
-module MiniTest
-  class Unit
-    class TestCase
+if defined?(Minitest::Test)
+  module Minitest
+    class Test
       include ::TimeWarpAbility
     end
   end
 end
 
-module RSpec
-  module Core
-    class ExampleGroup
-      include ::TimeWarpAbility
-     # Time warp to the specified time for the duration of the passed block.
+if defined?(MiniTest::Unit::TestCase)
+  module MiniTest
+    class Unit
+      class TestCase
+        include ::TimeWarpAbility
+      end
     end
   end
 end
 
-module Minitest
-  class Test
-    include ::TimeWarpAbility
+if defined?(RSpec::Core::ExampleGroup)
+  module RSpec
+    module Core
+      class ExampleGroup
+        include ::TimeWarpAbility
+       # Time warp to the specified time for the duration of the passed block.
+      end
+    end
   end
 end


### PR DESCRIPTION
See https://github.com/harvesthq/time-warp/pull/6 for more info.

That was out-of-date and included a huge diff due to the stuff that's now handled by https://github.com/harvesthq/time-warp/pull/13

The non-whitespace diff of that PR is pretty simple: https://github.com/harvesthq/time-warp/pull/6/files?w=1, and that's what's recreated here.

Credit given to the original author.

/cc @mrsimo @bjhess 
